### PR TITLE
add SSH wait logic to ensure droplet is ready before proceeding

### DIFF
--- a/infrastructure/create.sh
+++ b/infrastructure/create.sh
@@ -207,6 +207,18 @@ done
 doctl compute droplet-action power-on $DROPLET_ID --wait > /dev/null
 sleep 15s
 
+echo "Waiting for SSH to become available..."
+SSH_WAIT_REMAINING=20
+until ssh -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=no root@"$DROPLET_IP" true; do
+    ((SSH_WAIT_REMAINING--))
+    if [ "$SSH_WAIT_REMAINING" -le 0 ]; then
+        echo "SSH did not become available within expected time."
+        exit 1
+    fi
+    echo "SSH not ready yet, waiting 15 seconds..."
+    sleep 15s
+done
+
 echo "Droplet Finished Setup"
 
 ################################################################################


### PR DESCRIPTION
## Enable SSH readiness polling in `infrastructure/create.sh` to avoid premature remote deployment failure

### Summary
This change updates `infrastructure/create.sh` to wait for SSH availability on the newly created DigitalOcean droplet before attempting `scp` and `ssh` operations.

### Problem
Previously the script assumed the droplet would be ready for SSH after a fixed `sleep 15s` following power-on. That caused intermittent failures when the remote VM or `sshd` took longer than 15 seconds to start, producing:

```
ssh: connect to host ... port 22: Connection refused
```

Although the failure happened before the SQL restore step, it was actually a boot/service readiness race condition rather than a backup issue.

### Fix
- Added a retry loop that repeatedly attempts: `ssh -o BatchMode=yes -o ConnectTimeout=5 -o StrictHostKeyChecking=no root@"$DROPLET_IP" true`
- Retries up to `20` times with a `15s` wait between attempts
- Only proceeds once SSH responds successfully
- Exits cleanly if SSH never becomes available within the retry limit

### Why this helps
- Converts a fixed delay into a real readiness check
- Handles variable droplet boot times reliably
- Prevents `scp`/`ssh` commands from running too early
- Makes deployment more deterministic for slow-starting droplets

### Testing
- Verified the script now continues after an initial `Connection refused`
- Confirmed backup upload and restore complete successfully once SSH becomes ready

### Notes
This fix does not modify SQL restore behavior or backup handling; it only improves remote connection reliability during droplet provisioning.

<img width="1453" height="312" alt="image" src="https://github.com/user-attachments/assets/d6df5519-bf59-444a-9af6-f990a9bff372" />

